### PR TITLE
Fix: Add missing Coffee icon import in HomePage

### DIFF
--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { useAppContext } from '../context/AppContext';
 import Header from '../components/Header';
 import PersonCard from '../components/PersonCard';
-import { Plus } from 'lucide-react';
+import { Plus, Coffee } from 'lucide-react';
 
 const HomePage: React.FC = () => {
   const { people, selectPerson, setCurrentView } = useAppContext();


### PR DESCRIPTION
This commit resolves a "ReferenceError: Coffee is not defined" by adding the necessary import for the `Coffee` icon from `lucide-react` in `src/pages/HomePage.tsx`.

The `Coffee` icon was being used in the JSX to display when there are no outstanding coffees, but its import statement was missing. `PersonDetailsPage.tsx` was also reviewed and already had the correct import.