### PR TITLE
Refactor: Remove 'department' field from application

### DIFF
--- a/src/components/AddUserForm.tsx
+++ b/src/components/AddUserForm.tsx
@@ -13,7 +13,6 @@ const AddUserForm: React.FC<AddUserFormProps> = ({ performAddUser, onFormClose }
   const [formData, setFormData] = useState<UserFormData>({
     name: '',
     email: '',
-    department: '',
     avatar_url: ''
   });
 
@@ -49,17 +48,6 @@ const AddUserForm: React.FC<AddUserFormProps> = ({ performAddUser, onFormClose }
           required
           value={formData.email}
           onChange={(e) => setFormData({ ...formData, email: e.target.value })}
-          className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-orange-500 focus:ring-orange-500"
-        />
-      </div>
-
-      <div>
-        <label className="block text-sm font-medium text-gray-700">Department</label>
-        <input
-          type="text"
-          required
-          value={formData.department}
-          onChange={(e) => setFormData({ ...formData, department: e.target.value })}
           className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-orange-500 focus:ring-orange-500"
         />
       </div>

--- a/src/context/AppContext.tsx
+++ b/src/context/AppContext.tsx
@@ -105,7 +105,6 @@ export const AppProvider: React.FC<{children: React.ReactNode}> = ({ children })
         coffeesOwed: coffeesOwed,
         color: '#CCCCCC', // Default color
         email: user.email,
-        department: user.department,
       } as Person; // Type assertion if necessary for stricter type checking
     });
     setPeople(newPeople);
@@ -178,7 +177,6 @@ export const AppProvider: React.FC<{children: React.ReactNode}> = ({ children })
         typeof potentialNewUser.name === 'string' && potentialNewUser.name.trim() !== '' &&
         typeof potentialNewUser.avatar_url === 'string' && // Allows empty string for avatar_url
         typeof potentialNewUser.email === 'string' && // Basic check, could be stricter regex
-        typeof potentialNewUser.department === 'string' && // Allows empty string
         typeof potentialNewUser.created_at === 'string' // Basic check, could be Date validation
       ) {
         const validatedNewUser: DBUser = {
@@ -186,7 +184,6 @@ export const AppProvider: React.FC<{children: React.ReactNode}> = ({ children })
           name: potentialNewUser.name,
           email: potentialNewUser.email,
           avatar_url: potentialNewUser.avatar_url,
-          department: potentialNewUser.department,
           created_at: potentialNewUser.created_at,
         };
         setUsers(currentUsers => [...currentUsers, validatedNewUser]);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -5,7 +5,6 @@ export interface Person {
   coffeesOwed: number;
   color: string;
   email?: string;
-  department?: string;
 }
 
 export interface DBUser {
@@ -13,7 +12,6 @@ export interface DBUser {
   name: string;
   email: string;
   avatar_url: string;
-  department: string;
   created_at: string;
 }
 
@@ -30,6 +28,5 @@ export type AppView = 'home' | 'log' | 'profile';
 export interface UserFormData {
   name: string;
   email: string;
-  department: string;
   avatar_url: string;
 }


### PR DESCRIPTION
This commit removes the 'department' field entirely from the application's frontend codebase.

Key changes include:
- Updated type definitions (`DBUser`, `Person`, `UserFormData` in `src/types/index.ts`) to remove the `department` property.
- Modified `src/components/AddUserForm.tsx` to remove the input field for 'Department' and its corresponding state management.
- Updated `src/context/AppContext.tsx`:
    - Removed `department` from user creation logic in `addUser` (data sent to Supabase, validation of returned data).
    - Removed `department` from the `Person` object creation in the effect that derives the `people` array.
- Reviewed UI components (`PersonCard.tsx`, `ProfilePage.tsx`, `PersonDetailsPage.tsx`) and confirmed `department` was not being displayed.

You will need to manually remove the `department` column from your `users` table in Supabase to align the database schema with these changes.